### PR TITLE
fix for svg href (cnange to xlink:href) for safari

### DIFF
--- a/src/app/contacts/contacts.component.html
+++ b/src/app/contacts/contacts.component.html
@@ -12,7 +12,7 @@
       <li>
         <div class="contact-item-name">Директор, Секретар</div>
         <svg width="16" height="16" class="contact-item-pic">
-          <use href="assets/images/contact-icons.svg#phone"></use>
+          <use xlink:href="assets/images/contact-icons.svg#phone"></use>
         </svg>
         <div class="contact-item-content"><a href="tel:+380472360720">(0472)36-07-20</a>
         </div>
@@ -20,7 +20,7 @@
       <li>
         <div class="contact-item-name">Адміністратор</div>
         <svg width="16" height="16" class="contact-item-pic">
-          <use href="assets/images/contact-icons.svg#phone"></use>
+          <use xlink:href="assets/images/contact-icons.svg#phone"></use>
         </svg>
         <div class="contact-item-content"><a href="tel:+380472360718">(0472)36-07-18</a>
         </div>
@@ -28,7 +28,7 @@
       <li>
         <div class="contact-item-name">Каса</div>
         <svg width="16" height="16" class="contact-item-pic">
-          <use href="assets/images/contact-icons.svg#phone"></use>
+          <use xlink:href="assets/images/contact-icons.svg#phone"></use>
         </svg>
         <div class="contact-item-content"><a href="tel:+380472360721">(0472)36-07-21</a>
         </div>
@@ -36,7 +36,7 @@
       <li>
         <div class="contact-item-name">Eлектронна пошта</div>
         <svg width="16" height="16" class="contact-item-pic">
-          <use href="assets/images/contact-icons.svg#mail"></use>
+          <use xlink:href="assets/images/contact-icons.svg#mail"></use>
         </svg>
         <div class="contact-item-content"><a href="mailto:theatre.cherkasy@gmail.com">theatre.cherkasy@gmail.com</a>
         </div>
@@ -44,7 +44,7 @@
       <li>
         <div class="contact-item-name">Звертайтеся за адресою</div>
         <svg width="16" height="16" class="contact-item-pic">
-          <use href="assets/images/contact-icons.svg#pin"></use>
+          <use xlink:href="assets/images/contact-icons.svg#pin"></use>
         </svg>
         <div class="contact-item-content">м. Черкаси, бул. Шевченка, 234</div>
       </li>


### PR DESCRIPTION
Возможно поможет с решением бага о неотображении svg картинок в сафари